### PR TITLE
Fixed issue with default subreddits not showing up

### DIFF
--- a/refresh_token/__init__.py
+++ b/refresh_token/__init__.py
@@ -3,7 +3,7 @@
 from r2.lib.plugin import Plugin
 
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 
 class RefreshToken(Plugin):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes mitodl/open-discussions#57

#### What's this PR do?
Adds code that subscribes the user to the default subreddits.

#### How should this be manually tested?
Add the following settings in reddit-config/r2/local.update and reprovision vagrant (the values should be channel name values):
```
[DEFAULT]
automatic_reddits = micromasters,dedp
```

Create a new django user and login as them and verify the default channels you configured appear.
