### PR TITLE
Switch to Subreddit.subscribe_defaults() for adding subscriptions

### DIFF
--- a/refresh_token/__init__.py
+++ b/refresh_token/__init__.py
@@ -3,7 +3,7 @@
 from r2.lib.plugin import Plugin
 
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 
 
 class RefreshToken(Plugin):

--- a/refresh_token/controller.py
+++ b/refresh_token/controller.py
@@ -33,10 +33,10 @@ class RefreshTokenController(MinimalController):
         except NotFound:
             account = register(username, uuid4().hex, '127.0.0.1')
 
-        # this does the same thing that Subreddit.subscribe_default()
-        # should be doing, but doesn't for reasons we didn't want to investigate
+        # subscribe the user now because reddit does not have consistency across
+        # its APIs on what it considers the user to be subscribed to
         if not account.has_subscribed:
-            Subreddit.subscribe_multiple(account, Subreddit._by_name(g.automatic_reddits).values())
+            Subreddit.subscribe_defaults(account)
             account.has_subscribed = True
             account._commit()
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 pylint
-pytest
-pytest-pep8
+pytest==3.2.0
+pytest-pep8==1.0.6
 pytest-pylint
 tox


### PR DESCRIPTION
#### What are the relevant tickets?

Part of https://github.com/mitodl/open-discussions/issues/1974

#### What's this PR do?
- Switches to a different method for generating subscriptions for a new user, this aligns with how reddit 
- Pins a few dependencies for which newer versions were failing the tests

#### How should this be manually tested?
- Checkout this branch in your current clone of the project in the sibling directory to wherever you have `reddit-config`
- Run `vagrant reload && vagrant provision`
- Ensure you have at least one public default reddit (shows on frontpage and sidebar up when logged out)
- Register and confirm you still see the same data in the sidebar and frontpage'
- Register in MM and confirm you get the defaults plus any configured MM channels